### PR TITLE
Fix building of minimal

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,9 +7,6 @@ pub const chips = @import("src/chips.zig");
 pub fn build(b: *std.build.Builder) void {
     const optimize = b.standardOptimizeOption(.{});
     inline for (@typeInfo(boards).Struct.decls) |decl| {
-        if (!decl.is_pub)
-            continue;
-
         const exe = microzig.addEmbeddedExecutable(b, .{
             .name = @field(boards, decl.name).name ++ ".minimal",
             .source_file = .{
@@ -22,9 +19,6 @@ pub fn build(b: *std.build.Builder) void {
     }
 
     inline for (@typeInfo(chips).Struct.decls) |decl| {
-        if (!decl.is_pub)
-            continue;
-
         const exe = microzig.addEmbeddedExecutable(b, .{
             .name = @field(chips, decl.name).name ++ ".minimal",
             .source_file = .{


### PR DESCRIPTION
Since https://github.com/ziglang/zig/commit/3c08fe931a10618950c6af9e89226d1d9b20bbb9 @typeInfo will not return public decls. This breaks build.zig which was trying to check now not-existing field .is_pub of decl.